### PR TITLE
set version and pypi name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,10 @@
 
 An extensible MCMC framework for 21cmFAST.
 
+
+This code uses `semantic versioning <https://semver.org>`_, though this will strictly
+begin when `v1.0.0` is officially shipped.
+
 * Free software: MIT license
 
 Features

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def find_version(*file_paths):
 # ======================================================================================================================
 
 setup(
-    name="py21cmmc",
+    name="21CMMC",
     version=find_version("src", "py21cmmc", "__init__.py"),
     license="MIT license",
     description="An extensible MCMC framework for 21cmFAST",
@@ -76,7 +76,7 @@ setup(
         "emcee<3",
         "powerbox>=0.5.7",
         "cached_property",
-        "py21cmfast",
+        "21cmFAST>=3.0.0dev",
     ],
     # entry_points={
     #     'console_scripts': [

--- a/src/py21cmmc/__init__.py
+++ b/src/py21cmmc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "1.0.0dev"
 
 from .core import (
     CoreCoevalModule,


### PR DESCRIPTION
Sets the PyPI name to `21CMMC` and the first PyPI version number to 1.0.0 -- for now it is 1.0.0dev until all changes have been made such that we are happy with releasing. 