### PR TITLE
Enable default fault handler

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands=
 [testenv]
 passenv = TRAVIS TRAVIS_*
 setenv =
+    PYTHONFAULTHANDLER = 1
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
Enables the fault handler (same as recent PR for 21cmFAST).