### PR TITLE
fix pip installation files and add pipenv support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,20 +4,13 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-
-[packages]
-click = "*"
-numpy = "*"
-cffi = "*"
-scipy = "*"
-astropy = "*"
 corner = "*"
-pytest = "*"
 pytest-cov = "*"
 pre-commit = "*"
 tox = "*"
-21cmfast = {git = "git://github.com/21cmFAST/21cmFAST"}
-PyYAML = "*"
+
+[packages]
+21cmfast = {editable = true,git = "git://github.com/21cmfast/21cmFAST"}
 21cmmc = {editable = true,path = "."}
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,24 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+click = "*"
+numpy = "*"
+cffi = "*"
+scipy = "*"
+astropy = "*"
+corner = "*"
+pytest = "*"
+pytest-cov = "*"
+pre-commit = "*"
+tox = "*"
+21cmfast = {git = "git://github.com/21cmFAST/21cmFAST"}
+PyYAML = "*"
+21cmmc = {editable = true,path = "."}
+
+[requires]
+python_version = "3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,4 +9,4 @@ pytest
 pytest-cov
 pre-commit
 tox
-git+git://github.com/21cmFAST/21cmFAST#egg=21cmFAST
+21cmFAST @ git+git://github.com/21cmFAST/21cmFAST#egg=21cmFAST

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,4 +9,4 @@ pytest
 pytest-cov
 pre-commit
 tox
-git+git://github.com/21cmFAST/21cmFAST
+git+git://github.com/21cmFAST/21cmFAST#egg=21cmFAST

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "emcee<3",
         "powerbox>=0.5.7",
         "cached_property",
-        "21cmFAST @ git+git://github.com/21cmfast/21cmFAST#egg=21cmFAST",
+        "21cmFAST>=3.0.0dev",
     ],
     # entry_points={
     #     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "emcee<3",
         "powerbox>=0.5.7",
         "cached_property",
+        "21cmFAST @ git+git://github.com/21cmfast/21cmFAST#egg=21cmFAST",
     ],
     # entry_points={
     #     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url="https://github.com/21cmFAST/21CMMC",
     packages=find_packages("src"),
     package_dir={"": "src"},
-    package_data={"py21cmmc": "data/*"},
+    package_data={"py21cmmc": ["data/*"]},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
     zip_safe=False,
@@ -76,7 +76,6 @@ setup(
         "emcee<3",
         "powerbox>=0.5.7",
         "cached_property",
-        "21cmFAST>=3.0.0dev",
     ],
     # entry_points={
     #     'console_scripts': [


### PR DESCRIPTION
Temporary fix of `pip` installation files.
For `package_data` location, I left it as `data/*`.

I've also added Pipfile for `pipenv`.
`pipenv install` creates new virtual environment and installs all packages.