### PR TITLE
version bump

### DIFF
--- a/src/py21cmmc/__init__.py
+++ b/src/py21cmmc/__init__.py
@@ -1,6 +1,6 @@
 """21CMMC: a package for running MCMC analyses using 21cmFAST."""
 
-__version__ = "1.0.0dev2"
+__version__ = "1.0.0dev3"
 from .analyse import get_samples, load_primitive_chain
 from .core import (
     CoreCoevalModule,


### PR DESCRIPTION
This PR simply bumps the version to 1.0.0dev3, which enables us to make a new PyPI version that works with 21cmFAST v3.

I was supposed to do this on the previous branch.