### PR TITLE
reference ParameterError in multinest likelihood

### DIFF
--- a/src/py21cmmc/mcmc.py
+++ b/src/py21cmmc/mcmc.py
@@ -6,7 +6,6 @@ from os import mkdir, path
 from py21cmfast import yaml
 from py21cmfast._utils import ParameterError
 
-
 from .cosmoHammer import (
     CosmoHammerSampler,
     HDFStorageUtil,
@@ -211,22 +210,18 @@ Likelihood {} was defined to re-simulate data/noise, but this is incompatible wi
     if use_multinest:
 
         def likelihood(p, ndim, nparams):
-            inp = [
-                params[i][1] + p[i] * (params[i][2] - params[i][1]) for i in range(ndim)
-            ]
             try:
                 return chain.computeLikelihoods(
                     chain.build_model_data(
-                        Params(*[(k, v) for k, v in zip(params.keys, inp)])
+                        Params(*[(k, v) for k, v in zip(params.keys, p)])
                     )
                 )
             except ParameterError:
                 return -np.inf
 
         def prior(p, ndim, nparams):
-            p = [
-                params[i][1] + p[i] * (params[i][2] - params[i][1]) for i in range(ndim)
-            ]
+            for i in range(ndim):
+                p[i] = params[i][1] + p[i] * (params[i][2] - params[i][1])
 
         try:
             sampler = run(

--- a/src/py21cmmc/mcmc.py
+++ b/src/py21cmmc/mcmc.py
@@ -1,8 +1,11 @@
 """High-level functions for running MCMC chains."""
 import logging
+import numpy as np
 from concurrent.futures import ProcessPoolExecutor
 from os import mkdir, path
 from py21cmfast import yaml
+from py21cmfast._utils import ParameterError
+
 
 from .cosmoHammer import (
     CosmoHammerSampler,
@@ -211,11 +214,14 @@ Likelihood {} was defined to re-simulate data/noise, but this is incompatible wi
             inp = [
                 params[i][1] + p[i] * (params[i][2] - params[i][1]) for i in range(ndim)
             ]
-            return chain.computeLikelihoods(
-                chain.build_model_data(
-                    Params(*[(k, v) for k, v in zip(params.keys, inp)])
+            try:
+                return chain.computeLikelihoods(
+                    chain.build_model_data(
+                        Params(*[(k, v) for k, v in zip(params.keys, inp)])
+                    )
                 )
-            )
+            except ParameterError:
+                return -np.inf
 
         def prior(p, ndim, nparams):
             p = [

--- a/src/py21cmmc/mcmc.py
+++ b/src/py21cmmc/mcmc.py
@@ -6,7 +6,6 @@ from os import mkdir, path
 from py21cmfast import yaml
 from py21cmfast._utils import ParameterError
 
-
 from .cosmoHammer import (
     CosmoHammerSampler,
     HDFStorageUtil,


### PR DESCRIPTION
Due to not calling `LikelihoodComputationChain` `__call__` function directly, `ParameterError` is not catched. This makes MultiNest return `NaNs` instead of `-np.inf`.
`ParameterError` catch is thus added to the likelihood function directly.